### PR TITLE
Improve the build steps

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,6 @@
+ignored:
+  - DL3008
+  - DL3013
+
+trustedRegistries:
+  - docker.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+##############################################################################
+# Copyright (c) 2017 Real-Time Innovations, Inc.
+# All rights reserved. RTI grants Licensee a license to use, modify,
+# compile, and create derivative works of the Software.  Licensee has the right
+# to distribute object form only for use with RTI products. The Software
+# is provided "as is", with no warranty of any type, including any warranty for
+# fitness for any purpose. RTI is under no obligation to maintain or
+# support the Software.  RTI shall not be liable for any incidental
+# or consequential damages arising out of the use or inability to
+# use the software.
+##############################################################################
+sudo: false
+language: generic
+env:
+  HADOLINT: "${HOME}/hadolint"
+install:
+  - curl -sL -o ${HADOLINT} "https://github.com/hadolint/hadolint/releases/download/v1.9.0/hadolint-$(uname -s)-$(uname -m)" && chmod 700 ${HADOLINT}
+script:
+  - ${HADOLINT} Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2005-2014 Real-Time Innovations, Inc.
+# Copyright (c) 2017 Real-Time Innovations, Inc.
 # All rights reserved. RTI grants Licensee a license to use, modify,
 # compile, and create derivative works of the Software.  Licensee has the right
 # to distribute object form only for use with RTI products. The Software
@@ -11,55 +11,57 @@
 ##############################################################################
 FROM debian:buster-slim as builder
 LABEL "com.example.vendor"="Real-Time Innovations" \
-    version="1.1" \
+    version="1.2" \
     maintainer="israel@rti.com" \
     description="This image helps you to debug your network issues with \
     RTI Connext DDS and RTI Micro."
 
-# Install some packages:
+# Install some packages
 RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    zip
+        build-essential \
+        git \
+        zip \
+        curl \
+        dnsutils \
+        iperf \
+        iproute2 \
+        iputils-* \
+        nmap \
+        net-tools \
+        netcat \
+        python \
+        python-pip \
+        tcpdump \
+        tcpflow \
+        traceroute \
+        vim \
+        wget \
+        python-setuptools
+
+# Install RTI Connector
+RUN git clone --recurse-submodules \
+        https://github.com/rticommunity/rticonnextdds-connector-py.git && \
+    pip install -e rticonnextdds-connector-py && \
+    rm -rf \
+        /usr/local/lib/python2.7/dist-packages/lib/armv6vfphLinux3.xgcc4.7.2 \
+        /usr/local/lib/python2.7/dist-packages/lib/armv7aAndroid2.3gcc4.8 \
+        /usr/local/lib/python2.7/dist-packages/lib/armv7aQNX6.5.0SP1qcc_cpp4.4.2 \
+        /usr/local/lib/python2.7/dist-packages/lib/i86Linux3.xgcc4.6.3 \
+        /usr/local/lib/python2.7/dist-packages/lib/i86Win32VS2010 \
+        /usr/local/lib/python2.7/dist-packages/lib/x64Darwin16clang8.0 \
+        /usr/local/lib/python2.7/dist-packages/lib/x64Win64VS2013 && \
+    apt-get autoremove -y
 
 # Install RTI Logparser
 RUN git clone https://github.com/rticommunity/rticonnextdds-logparser.git
-WORKDIR /rticonnextdds-logparser
-RUN ./create_redist.sh
-
-
-FROM debian:buster-slim
-COPY --from=builder /rticonnextdds-logparser/rtilogparser /bin
-
-# Install some packages:
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    dnsutils \
-    iperf \
-    iproute2 \
-    iputils-* \
-    nmap \
-    net-tools \
-    netcat \
-    python \
-    python-pip \
-    tcpdump \
-    tcpflow \
-    traceroute \
-    vim \
-    wget \
-    python-setuptools && \
-    pip install rticonnextdds_connector && rm -rf \
-    /usr/local/lib/python2.7/dist-packages/lib/armv6vfphLinux3.xgcc4.7.2 \
-    /usr/local/lib/python2.7/dist-packages/lib/armv7aAndroid2.3gcc4.8 \
-    /usr/local/lib/python2.7/dist-packages/lib/armv7aQNX6.5.0SP1qcc_cpp4.4.2 \
-    /usr/local/lib/python2.7/dist-packages/lib/i86Linux3.xgcc4.6.3 \
-    /usr/local/lib/python2.7/dist-packages/lib/i86Win32VS2010 \
-    /usr/local/lib/python2.7/dist-packages/lib/x64Darwin16clang8.0 \
-    /usr/local/lib/python2.7/dist-packages/lib/x64Win64VS2013 && \
-    apt-get remove python-setuptools -y && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR rticonnextdds-logparser
+RUN ./create_redist.sh && \
+    cp /rticonnextdds-logparser/rtilogparser /usr/local/bin/
 
 # Add the ddsping application to the container
-COPY ddsping.py /bin/ddsping
-COPY PingConfiguration.xml /bin
+COPY ddsping.py /usr/local/bin/ddsping
+COPY PingConfiguration.xml /usr/local/bin
+
+FROM debian:buster-slim
+
+COPY --from=builder /usr /usr

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ LABEL "com.example.vendor"="Real-Time Innovations" \
     RTI Connext DDS and RTI Micro."
 
 # Install some packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         git \
         zip \
@@ -54,7 +54,7 @@ RUN git clone --recurse-submodules \
 
 # Install RTI Logparser
 RUN git clone https://github.com/rticommunity/rticonnextdds-logparser.git
-WORKDIR rticonnextdds-logparser
+WORKDIR /rticonnextdds-logparser
 RUN ./create_redist.sh && \
     cp /rticonnextdds-logparser/rtilogparser /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # RTI Docker Debugger
 
+[![Build Status](https://travis-ci.org/rticommunity/rticonnextdds-docker-debugger.svg?branch=master)](https://travis-ci.org/rticommunity/rticonnextdds-docker-debugger)
+
 This Docker image helps you to create a Docker container with some interesting
 tools to debug your system.
 
 ### License
 All programs and components within this image are the property of their
 respective owners under the license associated with such component in the
-installation.  Please refer to the documentation associated with each program
-or component and/or the [Licenses.md](Licenses.md) file included in the
-Docker image.
+installation. Please refer to the documentation associated with each program
+or component and/or the [Licenses.md](Licenses.md) file.
 
 ## Included tools
 
@@ -32,9 +33,9 @@ optional arguments:
 
 [RTI Log Parser](https://github.com/rticommunity/rticonnextdds-logparser)
 is also incorporated to make easier to debug your RTI Connext DDS and RTI
-Micro applications. You can call this tool directly from any directory 
+Micro applications. You can call this tool directly from any directory
 running ``rtilogparser [options]``. All the documentation about this tool is
-available in the 
+available in the
 [oficial repository of RTI Log Parser](https://github.com/rticommunity/rticonnextdds-logparser).
 
 ### Other applications included in this Docker image
@@ -74,22 +75,28 @@ These packages are:
 
 ## How to use this Docker image
 
-The idea of this Docker image is to provide you with a mechanism to debug 
+The idea of this Docker image is to provide you with a mechanism to debug
 issues that can made your system miscommunicate (mainly network issues).
 
 ### Build the image
 First, you need to clone this repository and build the image.
 When you finish to download the repository, you can go to it and run:
 
-``$ docker build -t rtidebugger .``
+```bash
+$ docker build -t rtidebugger .
+```
 
 ### Run the image
 
-You can run a ``bash`` process on your Docker container and interact with it. 
+You can run a ``bash`` process on your Docker container and interact with it.
 You can do it with the following command:
 
-    $ docker run --network=host --name debugger -ti rtidebugger:latest /bin/bash
+```bash
+$ docker run --network=host --name debugger -ti rtidebugger:latest /bin/bash
+```
 
 Also, you can run the different installed packages directly from the run command:
 
-    $ docker run --network=bridge --name debugger -ti rtidebugger:latest ping rti.com
+```bash
+$ docker run --network=bridge --name debugger -ti rtidebugger:latest ping rti.com
+```

--- a/ddsping.py
+++ b/ddsping.py
@@ -41,7 +41,7 @@ def writer():
     print("Running writer...")
 
     connector = rti.Connector("MyParticipantLibrary::Zero",
-                              "/bin/PingConfiguration.xml")
+                              "/usr/local/bin/PingConfiguration.xml")
 
     outputDDS = connector.getOutput("MyPublisher::PingWriter")
 


### PR DESCRIPTION
The image was refactored. Now, the size is smaller.
Solves #3, getting RTI Connector from the source code repository.

Also, add the Travis file.